### PR TITLE
Refactoring, Same feature, just divide into several files

### DIFF
--- a/header/crypto_util.h
+++ b/header/crypto_util.h
@@ -1,0 +1,9 @@
+#ifndef CRYPTO_UTIL_H
+#define CRYPTO_UTIL_H
+
+#include <string>
+
+std::string encrypt(const std::string& plain);
+std::string decrypt(const std::string& cipher_b64);
+
+#endif

--- a/src/crypto_util.cpp
+++ b/src/crypto_util.cpp
@@ -1,0 +1,48 @@
+#include "../header/crypto_util.h"
+#include <cryptopp/aes.h>
+#include <cryptopp/modes.h>
+#include <cryptopp/filters.h>
+#include <cryptopp/base64.h>
+
+using namespace std;
+
+/**
+ * 테스트 용으로 간단한 key와 iv로 설정하였다.
+ * TODO: 생성된 key와 무작위 iv 입력받기
+ */
+CryptoPP::byte key[CryptoPP::AES::DEFAULT_KEYLENGTH] = { 0 };
+CryptoPP::byte iv[CryptoPP::AES::BLOCKSIZE] = { 0 };
+
+/**
+ * 평문을 입력받아 전역 key와 iv를 사용해 암호화된 문자열을 반환한다.
+ */
+string encrypt(const string& plain) {
+    // 1) AES-CBC로 암호화
+    string cipher;
+    CryptoPP::CBC_Mode<CryptoPP::AES>::Encryption enc;
+    enc.SetKeyWithIV(key, sizeof(key), iv);
+    CryptoPP::StringSource ss1(plain, true, new CryptoPP::StreamTransformationFilter(enc, new CryptoPP::StringSink(cipher)));
+
+    // 2) 바이너리를 Base64로 변환
+    string cipher_b64;
+    CryptoPP::StringSource ss2(cipher, true, new CryptoPP::Base64Encoder(new CryptoPP::StringSink(cipher_b64), false));
+
+    return cipher_b64;
+}
+
+/**
+ * 암호문을 입력받아 전역 key와 iv를 사용해 복호화된 문자열을 반환한다.
+ */
+string decrypt(const string& cipher_b64) {
+    // 1) Base64를 바이너리로 변환
+    string cipher;
+    CryptoPP::StringSource ss1(cipher_b64, true, new CryptoPP::Base64Decoder(new CryptoPP::StringSink(cipher)));
+
+    // 2) AES-CBC로 복호화
+    string plain;
+    CryptoPP::CBC_Mode<CryptoPP::AES>::Decryption dec;
+    dec.SetKeyWithIV(key, sizeof(key), iv);
+    CryptoPP::StringSource ss2(cipher, true, new CryptoPP::StreamTransformationFilter(dec, new CryptoPP::StringSink(plain)));
+
+    return plain;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,54 +4,11 @@
 #include <vector>
 #include <optional>
 #include <algorithm>
+#include "../header/crypto_util.h"
 
-#include <cryptopp/aes.h>
-#include <cryptopp/modes.h>
-#include <cryptopp/filters.h>
-#include <cryptopp/base64.h>
 
 using namespace std;
 
-/**
- * 테스트 용으로 간단한 key와 iv로 설정하였다.
- * TODO: 생성된 key와 무작위 iv 입력받기
- */
-CryptoPP::byte key[CryptoPP::AES::DEFAULT_KEYLENGTH] = {0};
-CryptoPP::byte iv[CryptoPP::AES::BLOCKSIZE] = {0};
-
-/** 
- * 평문을 입력받아 전역 key와 iv를 사용해 암호화된 문자열을 반환한다.
- */
-string encrypt(const string& plain) {
-    // 1) AES-CBC로 암호화
-    string cipher;
-    CryptoPP::CBC_Mode<CryptoPP::AES>::Encryption enc;
-    enc.SetKeyWithIV(key, sizeof(key), iv);
-    CryptoPP::StringSource ss1(plain, true, new CryptoPP::StreamTransformationFilter(enc, new CryptoPP::StringSink(cipher)));
-
-    // 2) 바이너리를 Base64로 변환
-    string cipher_b64;
-    CryptoPP::StringSource ss2(cipher, true, new CryptoPP::Base64Encoder(new CryptoPP::StringSink(cipher_b64), false));
-
-    return cipher_b64;
-}
-
-/**
- * 암호문을 입력받아 전역 key와 iv를 사용해 복호화된 문자열을 반환한다.
- */
-string decrypt(const string& cipher_b64) {
-    // 1) Base64를 바이너리로 변환
-    string cipher;
-    CryptoPP::StringSource ss1(cipher_b64, true, new CryptoPP::Base64Decoder(new CryptoPP::StringSink(cipher)));
-
-    // 2) AES-CBC로 복호화
-    string plain;
-    CryptoPP::CBC_Mode<CryptoPP::AES>::Decryption dec;
-    dec.SetKeyWithIV(key, sizeof(key), iv);
-    CryptoPP::StringSource ss2(cipher, true, new CryptoPP::StreamTransformationFilter(dec, new CryptoPP::StringSink(plain)));
-
-    return plain;
-}
 
 static const string DB_PATH = "data.log";
 


### PR DESCRIPTION
기존의 방식이 모든 기능이 main 파일에 합쳐져서 구현되고 있어서 이를 나누었습니다. 일반적으로 main 함수에서 사용하는 함수들은 헤더파일에서 선언하고 cpp파일로 정의하는 것이 일반적이기에 그렇게 해두었습니다. 그리고 put, get, del 등의 저장소와 관련된 operation 함수들은 앞으로 nbdkit의 플러그인, 즉 인터페이스로 만들 예정인데 이것은 아직 만들지 않아서 main 함수에 그대로 놔두었습니다. 제가 간략하게 생각한 방향으로 구현이 될 경우 현재 main 함수에서 get, put 과 같은 함수가 사라지고 새로 만들 인터페이스 파일에 구현되는 함수들을 이용하게 될 것이라고 생각하면 될 것 같습니다. 

현재까지 수현님이 만드신 거에서 기능적인 차이는 없고, 단순히 코드를 여러 파일로 나누었을 뿐입니다. 
암호화와 관련된 함수들은 crypto_util.h와 crypto_util.cpp 파일에 나누었습니다. 헤더파일에는 함수의 정의를 소스파일에는 해당 함수의 정의를 넣어두었습니다. 

파일이 늘어나면서 기존에 빌드하실때는 빌드에 src/main.cpp 이거만 있었지만 추가적으로 src/crypto_util.cpp도 추가하셔야 합니다.
제 리눅스 환경에서는 g++ -std=c++17 -O2 -I/usr/local/include/cryptopp src/main.cpp src/crypto_util.cpp /usr/local/lib/libcryptopp.a -o optimus_kv 으로 빌드하였습니다. 


위와 같이 사용하게 될 경우, nbdkit을 이용해 우리가 만든 간단한 저장소를 블록 디스크처럼 인식하여 사용할때, 사용자가 파일을 새로 만들면 알아서 nbd 서버의 플러그인으로 만든 해당 함수가 호출되면서 작동하는 방식입니다. 저도 nbdkit의 방식에 대해서 100% 이해한 것은 아니라서 이정도가 제가 말할 수 있는 정도인 것 같습니다. 